### PR TITLE
Add top level APIs for fetching secrets

### DIFF
--- a/azure-key-vault/Azure/Secret/Types.hs
+++ b/azure-key-vault/Azure/Secret/Types.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Azure.Secret.Types
+    ( KeyVaultResponse (..)
+    , SecretName (..)
+    , KeyVaultHost (..)
+    ) where
+
+import Data.Aeson (FromJSON (..), withObject, (.:))
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+newtype KeyVaultResponse = KeyVaultResponse
+    { unKeyValueReponse :: Text
+    }
+    deriving stock (Eq, Show, Generic)
+
+instance FromJSON KeyVaultResponse where
+    parseJSON = withObject "KeyVaultResponse" $ \o -> do
+        unKeyValueReponse <- o .: "value"
+        pure KeyVaultResponse{..}
+
+newtype SecretName = SecretName {unSecretName :: Text} deriving stock (Eq, Show)
+
+newtype KeyVaultHost = KeyVaultHost {unKeyVaultHost :: Text} deriving stock (Eq, Show)

--- a/azure-key-vault/azure-key-vault.cabal
+++ b/azure-key-vault/azure-key-vault.cabal
@@ -62,3 +62,13 @@ library
                     , text
                     , unliftio
     default-language: Haskell2010
+
+executable example
+  main-is: Main.hs
+  hs-source-dirs: example
+  ghc-options: -Wall
+  default-language: Haskell2010
+  build-depends:
+      base >= 4.7 && < 5
+    , azure-auth
+    , azure-key-vault

--- a/azure-key-vault/azure-key-vault.cabal
+++ b/azure-key-vault/azure-key-vault.cabal
@@ -52,7 +52,8 @@ common common-options
 
 library
     import:           common-options
-    exposed-modules:  Azure.Secret
+    exposed-modules:  Azure.Secret.Types
+                      Azure.Secret
     build-depends:    aeson
                     , azure-auth
                     , http-client-tls

--- a/azure-key-vault/example/Main.hs
+++ b/azure-key-vault/example/Main.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import Azure.Secret (getSecret)
+import Azure.Secret.Types (KeyVaultHost (..), SecretName (..))
+import Azure.Types (newEmptyToken)
+import Azure.Auth (defaultAzureCredential)
+
+main :: IO ()
+main = do
+    tok <- newEmptyToken
+    cred <- defaultAzureCredential Nothing "https://vault.azure.net" tok
+    -- In order to run this, you need to replace @SecretName@ and @KeyVaultHost@ with
+    -- appropriate values in your resource group. These are just dummy values.
+    getSecret (SecretName "radiohead") (KeyVaultHost "albums") cred >>= print


### PR DESCRIPTION
- Adds top level APIs for fetching secrets (`getSecret` and `getSecretEither`)
- Removes call to `defaultAzureCredentials` in client. Users need to supply `AccessToken`
- Split types and functions.

TODO:
- [x] Test
- [x] Examples